### PR TITLE
Add Configurable Author and Description Options and Display Them with `--help`

### DIFF
--- a/examples/multiple_app.rs
+++ b/examples/multiple_app.rs
@@ -13,6 +13,8 @@ fn main() {
 
     let app = App::new()
         .name(name)
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .description(env!("CARGO_PKG_DESCRIPTION"))
         .usage("multiple_app [command] [arg]")
         .version(env!("CARGO_PKG_VERSION"))
         .commands(vec![hello_command()]);

--- a/examples/single_app.rs
+++ b/examples/single_app.rs
@@ -13,6 +13,8 @@ fn main() {
 
     let app = SingleApp::new()
         .name(name)
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .description(env!("CARGO_PKG_DESCRIPTION"))
         .usage("single_app [args]")
         .version(env!("CARGO_PKG_VERSION"))
         .action(action)

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -17,7 +17,7 @@ impl Default for App {
             name: String::default(),
             display_name: String::default(),
             author: env!("CARGO_PKG_AUTHORS").to_owned(),
-            description: Some(env!("CARGO_PKG_AUTHORS").to_owned()),
+            description: Some(env!("CARGO_PKG_DESCRIPTION").to_owned()),
             usage: String::default(),
             version: env!("CARGO_PKG_VERSION").to_owned(),
             commands: Vec::<Command>::default()

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -16,10 +16,10 @@ impl Default for App {
         Self {
             name: String::default(),
             display_name: String::default(),
-            author: env!("CARGO_PKG_AUTHORS").to_owned(),
-            description: Some(env!("CARGO_PKG_DESCRIPTION").to_owned()),
+            author: String::default(),
+            description: None,
             usage: String::default(),
-            version: env!("CARGO_PKG_VERSION").to_owned(),
+            version: String::default(),
             commands: Vec::<Command>::default()
         }
     }

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -1,12 +1,28 @@
+use std::env;
 use crate::Command;
 
-#[derive(Default)]
 pub struct App {
     pub name: String,
     pub display_name: String,
+    pub author: String,
+    pub description: Option<String>,
     pub usage: String,
     pub version: String,
     pub commands: Vec<Command>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            name: String::default(),
+            display_name: String::default(),
+            author: env!("CARGO_PKG_AUTHORS").to_owned(),
+            description: Some(env!("CARGO_PKG_AUTHORS").to_owned()),
+            usage: String::default(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            commands: Vec::<Command>::default()
+        }
+    }
 }
 
 impl App {
@@ -21,6 +37,16 @@ impl App {
 
     pub fn display_name<T: Into<String>>(mut self, display_name: T) -> Self {
         self.display_name = display_name.into();
+        self
+    }
+
+    pub fn author<T: Into<String>>(mut self, author: T) -> Self {
+        self.author = author.into();
+        self
+    }
+
+    pub fn description<T: Into<String>>(mut self, description: T) -> Self {
+        self.description = Some(description.into());
         self
     }
 
@@ -77,6 +103,12 @@ impl App {
         match self.display_name.len() {
             0 => println!("Name:\n\t{}\n", self.name),
             _ => println!("Name:\n\t{}\n", self.display_name),
+        }
+
+        println!("Author:\n\t{}\n", self.author);
+
+        if let Some(description) = self.description.to_owned() {
+            println!("Description:\n\t{}\n", description);
         }
 
         println!("Usage:\n\t{}\n", self.usage);
@@ -137,6 +169,8 @@ mod tests {
             ]);
         let app = App::new()
             .name("test")
+            .author("Author <author@example.com>")
+            .description("This is a great tool.")
             .usage("test [command] [arg]")
             .version("0.0.1")
             .commands(vec![c]);
@@ -156,6 +190,8 @@ mod tests {
 
         assert_eq!(app.name, "test".to_string());
         assert_eq!(app.usage, "test [command] [arg]".to_string());
+        assert_eq!(app.author, "Author <author@example.com>".to_string());
+        assert_eq!(app.description, Some("This is a great tool.".to_string()));
         assert_eq!(app.version, "0.0.1".to_string());
     }
 }

--- a/src/app/single_app.rs
+++ b/src/app/single_app.rs
@@ -3,6 +3,8 @@ use crate::{Action, Context, Flag};
 pub struct SingleApp {
     pub name: String,
     pub display_name: String,
+    pub author: String,
+    pub description: Option<String>,
     pub usage: String,
     pub version: String,
     pub action: Action,
@@ -12,10 +14,12 @@ pub struct SingleApp {
 impl Default for SingleApp {
     fn default() -> Self {
         Self {
-            name: "".to_string(),
-            display_name: "".to_string(),
-            usage: "".to_string(),
-            version: "".to_string(),
+            name: String::default(),
+            display_name: String::default(),
+            author: env!("CARGO_PKG_AUTHORS").to_owned(),
+            description: Some(env!("CARGO_PKG_DESCRIPTION").to_owned()),
+            usage: String::default(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
             action: |c: &Context| println!("{:?}", c.args),
             flags: None,
         }
@@ -34,6 +38,16 @@ impl SingleApp {
 
     pub fn display_name<T: Into<String>>(mut self, display_name: T) -> Self {
         self.display_name = display_name.into();
+        self
+    }
+
+    pub fn author<T: Into<String>>(mut self, author: T) -> Self {
+        self.author = author.into();
+        self
+    }
+
+    pub fn description<T: Into<String>>(mut self, description: T) -> Self {
+        self.description = Some(description.into());
         self
     }
 
@@ -68,6 +82,12 @@ impl SingleApp {
         match self.display_name.len() {
             0 => println!("Name:\n\t{}\n", self.name),
             _ => println!("Name:\n\t{}\n", self.display_name),
+        }
+
+        println!("Author:\n\t{}\n", self.author);
+
+        if let Some(description) = self.description.to_owned() {
+            println!("Description:\n\t{}\n", description);
         }
 
         println!("Usage:\n\t{}", self.usage);

--- a/src/app/single_app.rs
+++ b/src/app/single_app.rs
@@ -16,10 +16,10 @@ impl Default for SingleApp {
         Self {
             name: String::default(),
             display_name: String::default(),
-            author: env!("CARGO_PKG_AUTHORS").to_owned(),
-            description: Some(env!("CARGO_PKG_DESCRIPTION").to_owned()),
+            author: String::default(),
+            description: None,
             usage: String::default(),
-            version: env!("CARGO_PKG_VERSION").to_owned(),
+            version: String::default(),
             action: |c: &Context| println!("{:?}", c.args),
             flags: None,
         }
@@ -135,6 +135,7 @@ mod tests {
         ]);
 
         assert_eq!(app.name, "test".to_string());
+        assert_eq!(app.description, None);
         assert_eq!(app.usage, "test [url]".to_string());
         assert_eq!(app.version, "0.0.1".to_string());
     }


### PR DESCRIPTION
Many other CLI tools support "author" and "description" attribute.
So, I  added them.
They will be displayed when users run command with --help.

like:

> <img width="432" alt="スクリーンショット 2020-02-17 12 21 25" src="https://user-images.githubusercontent.com/31783570/74621352-08970480-5180-11ea-9b90-b5f446228b49.png">
