### PR TITLE
Remove Redundant Code in App#run

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -230,11 +230,6 @@ impl App {
                     }
                 };
 
-                if cmd.is_empty() {
-                    self.help();
-                    return;
-                }
-
                 match self.select_command(&cmd) {
                     Some(command) => {
                         command.run(args_v.to_vec());


### PR DESCRIPTION
`env::args().collect()` does not contain empty string.