### PR TITLE
Enabling error handling in the action function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seahorse"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["ksk001100 <hm.pudding0715@gmail.com>"]
 edition = "2018"
 keywords = [

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use seahorse, add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-seahorse = "0.7.0"
+seahorse = "0.7.1"
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ $ cli sub 12 23 89
 ### Branch processing by flag
 
 ```rust
-use seahorse::{App, Command, Context, Flag, FlagType};
+use seahorse::{App, Command, Context, Flag, FlagType, error::FlagError};
 use std::env;
 
 fn main() {
@@ -159,14 +159,14 @@ fn default_action(c: &Context) {
         println!("Hello, {:?}", c.args);
     }
 
-    if let Some(age) = c.int_flag("age") {
+    if let Ok(age) = c.int_flag("age") {
         println!("{:?} is {} years old", c.args, age);
     }
 }
 
 fn calc_action(c: &Context) {
     match c.string_flag("operator") {
-        Some(op) => {
+        Ok(op) => {
             let sum: i32 = match &*op {
                 "add" => c.args.iter().map(|n| n.parse::<i32>().unwrap()).sum(),
                 "sub" => c.args.iter().map(|n| n.parse::<i32>().unwrap() * -1).sum(),
@@ -175,7 +175,13 @@ fn calc_action(c: &Context) {
 
             println!("{}", sum);
         }
-        None => panic!("undefined operator..."),
+        Err(e) => match e {
+            FlagType::Undefiled => panic!("undefined operator..."), 
+            FlagType::ArgumentError => panic!("argument error..."), 
+            FlagType::NotFound => panic!("not found flag..."), 
+            FlagType::ValueTypeError => panic!("value type mismatch..."), 
+            FlagType::TypeError => panic!("flag type mismatch..."), 
+        },
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ fn calc_action(c: &Context) {
             println!("{}", sum);
         }
         Err(e) => match e {
-            FlagType::Undefiled => panic!("undefined operator..."), 
-            FlagType::ArgumentError => panic!("argument error..."), 
-            FlagType::NotFound => panic!("not found flag..."), 
-            FlagType::ValueTypeError => panic!("value type mismatch..."), 
-            FlagType::TypeError => panic!("flag type mismatch..."), 
+            FlagError::Undefiled => panic!("undefined operator..."), 
+            FlagError::ArgumentError => panic!("argument error..."), 
+            FlagError::NotFound => panic!("not found flag..."), 
+            FlagError::ValueTypeError => panic!("value type mismatch..."), 
+            FlagError::TypeError => panic!("flag type mismatch..."), 
         },
     }
 }

--- a/examples/multiple_app.rs
+++ b/examples/multiple_app.rs
@@ -30,10 +30,20 @@ fn hello_action(c: &Context) {
     match c.int_flag("age") {
         Ok(age) => println!("{:?} is {} years old", c.args, age),
         Err(e) => match e {
-            FlagError::TypeError => println!("age type error"),
-            FlagError::Undefined => println!("undefined"),
-            FlagError::ArgumentError => println!("age argument error"),
-            FlagError::NotFound => println!("hogehoge"),
+            FlagError::TypeError => println!("age flag type error"),
+            FlagError::Undefined => println!("undefined age flag"),
+            FlagError::ArgumentError => println!("age flag argument error"),
+            FlagError::NotFound => println!("not found age flag"),
+        },
+    }
+
+    match c.int_flag("neko") {
+        Ok(age) => println!("{:?} is {} years old", c.args, age),
+        Err(e) => match e {
+            FlagError::TypeError => println!("age flag type error"),
+            FlagError::Undefined => println!("undefined age flag"),
+            FlagError::ArgumentError => println!("age flag argument error"),
+            FlagError::NotFound => println!("not found age flag"),
         },
     }
 }

--- a/examples/multiple_app.rs
+++ b/examples/multiple_app.rs
@@ -25,8 +25,8 @@ fn hello_action(c: &Context) {
     }
 
     match c.int_flag("age") {
-        Some(age) => println!("{:?} is {} years old", c.args, age),
-        None => println!("I don't know {:?}'s age", c.args),
+        Ok(age) => println!("{:?} is {} years old", c.args, age),
+        Err(e) => println!("{}", e),
     }
 }
 

--- a/examples/multiple_app.rs
+++ b/examples/multiple_app.rs
@@ -1,4 +1,4 @@
-use seahorse::{color, App, Command, Context, Flag, FlagType};
+use seahorse::{color, error::FlagError, App, Command, Context, Flag, FlagType};
 use std::env;
 
 fn main() {
@@ -29,7 +29,12 @@ fn hello_action(c: &Context) {
 
     match c.int_flag("age") {
         Ok(age) => println!("{:?} is {} years old", c.args, age),
-        Err(e) => println!("{}", e),
+        Err(e) => match e {
+            FlagError::TypeError => println!("age type error"),
+            FlagError::Undefined => println!("undefined"),
+            FlagError::ArgumentError => println!("age argument error"),
+            FlagError::NotFound => println!("hogehoge"),
+        },
     }
 }
 

--- a/examples/multiple_app.rs
+++ b/examples/multiple_app.rs
@@ -38,14 +38,14 @@ fn hello_action(c: &Context) {
         },
     }
 
-    match c.float_flag("age") {
-        Ok(age) => println!("{:?} is {} years old", c.args, age),
+    match c.string_flag("neko") {
+        Ok(neko) => println!("neko say {}", neko),
         Err(e) => match e {
-            FlagError::TypeError => println!("age flag type error"),
+            FlagError::TypeError => println!("neko flag type error"),
             FlagError::ValueTypeError => println!("value type error"),
-            FlagError::Undefined => println!("undefined age flag"),
-            FlagError::ArgumentError => println!("age flag argument error"),
-            FlagError::NotFound => println!("not found age flag"),
+            FlagError::Undefined => println!("undefined neko flag"),
+            FlagError::ArgumentError => println!("neko flag argument error"),
+            FlagError::NotFound => println!("not found neko flag"),
         },
     }
 }

--- a/examples/multiple_app.rs
+++ b/examples/multiple_app.rs
@@ -31,16 +31,18 @@ fn hello_action(c: &Context) {
         Ok(age) => println!("{:?} is {} years old", c.args, age),
         Err(e) => match e {
             FlagError::TypeError => println!("age flag type error"),
+            FlagError::ValueTypeError => println!("value type error"),
             FlagError::Undefined => println!("undefined age flag"),
             FlagError::ArgumentError => println!("age flag argument error"),
             FlagError::NotFound => println!("not found age flag"),
         },
     }
 
-    match c.int_flag("neko") {
+    match c.float_flag("age") {
         Ok(age) => println!("{:?} is {} years old", c.args, age),
         Err(e) => match e {
             FlagError::TypeError => println!("age flag type error"),
+            FlagError::ValueTypeError => println!("value type error"),
             FlagError::Undefined => println!("undefined age flag"),
             FlagError::ArgumentError => println!("age flag argument error"),
             FlagError::NotFound => println!("not found age flag"),

--- a/examples/single_app.rs
+++ b/examples/single_app.rs
@@ -3,15 +3,7 @@ use std::env;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let name = color::magenta(
-        "
-     ██████╗██╗     ██╗
-    ██╔════╝██║     ██║
-    ██║     ██║     ██║
-    ██║     ██║     ██║
-    ╚██████╗███████╗██║
-     ╚═════╝╚══════╝╚═╝",
-    );
+    let name = color::magenta("single_app");
 
     let app = App::new()
         .name(name)

--- a/src/app.rs
+++ b/src/app.rs
@@ -354,15 +354,15 @@ mod tests {
             assert_eq!(true, c.bool_flag("bool"));
             match c.string_flag("string") {
                 Ok(flag) => assert_eq!("string".to_string(), flag),
-                Err(_) => assert!(false, "string test false..."),
+                _ => assert!(false, "string test false..."),
             }
             match c.int_flag("int") {
                 Ok(flag) => assert_eq!(100, flag),
-                Err(_) => assert!(false, "int test false..."),
+                _ => assert!(false, "int test false..."),
             }
             match c.float_flag("float") {
                 Ok(flag) => assert_eq!(1.23, flag),
-                Err(_) => assert!(false, "float test false..."),
+                _ => assert!(false, "float test false..."),
             }
         };
         let c = Command::new("hello")
@@ -406,15 +406,15 @@ mod tests {
             assert_eq!(true, c.bool_flag("bool"));
             match c.string_flag("string") {
                 Ok(flag) => assert_eq!("string".to_string(), flag),
-                Err(_) => assert!(false, "string test false..."),
+                _ => assert!(false, "string test false..."),
             }
             match c.int_flag("int") {
-                Some(flag) => assert_eq!(100, flag),
-                None => assert!(false, "int test false..."),
+                Ok(flag) => assert_eq!(100, flag),
+                _ => assert!(false, "int test false..."),
             }
             match c.float_flag("float") {
-                Some(flag) => assert_eq!(1.23, flag),
-                None => assert!(false, "float test false..."),
+                Ok(flag) => assert_eq!(1.23, flag),
+                _ => assert!(false, "float test false..."),
             }
         };
 
@@ -453,16 +453,16 @@ mod tests {
         let action: Action = |c: &Context| {
             assert_eq!(true, c.bool_flag("bool"));
             match c.string_flag("string") {
-                Some(flag) => assert_eq!("string".to_string(), flag),
-                None => assert!(false, "string test false..."),
+                Ok(flag) => assert_eq!("string".to_string(), flag),
+                _ => assert!(false, "string test false..."),
             }
             match c.int_flag("int") {
-                Some(flag) => assert_eq!(100, flag),
-                None => assert!(false, "int test false..."),
+                Ok(flag) => assert_eq!(100, flag),
+                _ => assert!(false, "int test false..."),
             }
             match c.float_flag("float") {
-                Some(flag) => assert_eq!(1.23, flag),
-                None => assert!(false, "float test false..."),
+                Ok(flag) => assert_eq!(1.23, flag),
+                _ => assert!(false, "float test false..."),
             }
         };
 
@@ -500,16 +500,16 @@ mod tests {
         let action: Action = |c: &Context| {
             assert_eq!(true, c.bool_flag("bool"));
             match c.string_flag("string") {
-                Some(flag) => assert_eq!("str=ing".to_string(), flag),
-                None => assert!(false, "string test false..."),
+                Ok(flag) => assert_eq!("str=ing".to_string(), flag),
+                _ => assert!(false, "string test false..."),
             }
             match c.int_flag("int") {
-                Some(flag) => assert_eq!(100, flag),
-                None => assert!(false, "int test false..."),
+                Ok(flag) => assert_eq!(100, flag),
+                _ => assert!(false, "int test false..."),
             }
             match c.float_flag("float") {
-                Some(flag) => assert_eq!(1.23, flag),
-                None => assert!(false, "float test false..."),
+                Ok(flag) => assert_eq!(1.23, flag),
+                _ => assert!(false, "float test false..."),
             }
         };
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -355,16 +355,16 @@ mod tests {
         let a: Action = |c: &Context| {
             assert_eq!(true, c.bool_flag("bool"));
             match c.string_flag("string") {
-                Some(flag) => assert_eq!("string".to_string(), flag),
-                None => assert!(false, "string test false..."),
+                Ok(flag) => assert_eq!("string".to_string(), flag),
+                Err(_) => assert!(false, "string test false..."),
             }
             match c.int_flag("int") {
-                Some(flag) => assert_eq!(100, flag),
-                None => assert!(false, "int test false..."),
+                Ok(flag) => assert_eq!(100, flag),
+                Err(_) => assert!(false, "int test false..."),
             }
             match c.float_flag("float") {
-                Some(flag) => assert_eq!(1.23, flag),
-                None => assert!(false, "float test false..."),
+                Ok(flag) => assert_eq!(1.23, flag),
+                Err(_) => assert!(false, "float test false..."),
             }
         };
         let c = Command::new()
@@ -425,8 +425,8 @@ mod tests {
         let action: Action = |c: &Context| {
             assert_eq!(true, c.bool_flag("bool"));
             match c.string_flag("string") {
-                Some(flag) => assert_eq!("string".to_string(), flag),
-                None => assert!(false, "string test false..."),
+                Ok(flag) => assert_eq!("string".to_string(), flag),
+                Err(_) => assert!(false, "string test false..."),
             }
             match c.int_flag("int") {
                 Some(flag) => assert_eq!(100, flag),

--- a/src/command.rs
+++ b/src/command.rs
@@ -123,8 +123,6 @@ mod tests {
             .action(a)
             .flag(Flag::new("t", "t", FlagType::Bool));
 
-        &c.flags.unwrap()[0].value(&vec!["--hoge".to_string()]);
-
         assert_eq!(c.name, "hello".to_string());
         assert_eq!(c.usage, "test hello user".to_string());
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -94,12 +94,11 @@ impl Context {
     /// ```
     /// use seahorse::Context;
     ///
-    /// match context.string_flag("string") {
-    ///     Some(r) => match r {
+    /// fn action(c: &Context) {
+    ///     match c.string_flag("string") {
     ///         Ok(s) => println!("{}", s),
     ///         Err(e) => println!("{}", e)
-    ///     },
-    ///     None => println!("Not found string...")
+    ///     }
     /// }
     /// ```
     pub fn string_flag(&self, name: &str) -> Result<String, FlagError> {
@@ -108,14 +107,6 @@ impl Context {
             Err(e) => Err(e),
             _ => Err(FlagError::ArgumentError),
         }
-        // match self.result_flag_value(name) {
-        //     Some(r) => match r {
-        //         Ok(FlagValue::String(val)) => Some(Ok(val)),
-        //         Err(e) => Some(Err(e)),
-        //         _ => Some(Err("".to_string())),
-        //     },
-        //     None => None,
-        // }
     }
 
     /// Get int flag
@@ -125,12 +116,11 @@ impl Context {
     /// ```
     /// use seahorse::Context;
     ///
-    /// match context.int_flag("int") {
-    ///     Some(r) => match r {
+    /// fn action(c: &Context) {
+    ///     match c.int_flag("int") {
     ///         Ok(i) => println!("{}", i),
     ///         Err(e) => println!("{}", e)
     ///     }
-    ///     None => println!("Not found int number...")
     /// }
     /// ```
     pub fn int_flag(&self, name: &str) -> Result<isize, FlagError> {
@@ -139,14 +129,6 @@ impl Context {
             Err(e) => Err(e),
             _ => Err(FlagError::ArgumentError),
         }
-        // match self.result_flag_value(name) {
-        //     Some(r) => match r {
-        //         Ok(FlagValue::Int(val)) => Some(Ok(val)),
-        //         Err(e) => Some(Err(e.to_owned())),
-        //         _ => Some(Err("".to_string())),
-        //     },
-        //     None => None,
-        // }
     }
 
     /// Get float flag
@@ -156,12 +138,11 @@ impl Context {
     /// ```
     /// use seahorse::Context;
     ///
-    /// match context.float_flag("float") {
-    ///     Some(r) => match r {
+    /// fn action(c: &Context) {
+    ///     match c.float_flag("float") {
     ///         Ok(f) => println!("{}", f),
     ///         Err(e) => println!("{}", e)
     ///     }
-    ///     None => println!("Not found float number...")
     /// }
     /// ```
     pub fn float_flag(&self, name: &str) -> Result<f64, FlagError> {
@@ -170,14 +151,6 @@ impl Context {
             Err(e) => Err(e),
             _ => Err(FlagError::ArgumentError),
         }
-        // match self.result_flag_value(name) {
-        //     Some(r) => match r {
-        //         Ok(FlagValue::Float(val)) => Some(Ok(val)),
-        //         Err(e) => Some(Err(e.to_owned())),
-        //         _ => Some(Err("".to_string())),
-        //     },
-        //     None => None,
-        // }
     }
 
     /// Display help
@@ -237,23 +210,5 @@ mod tests {
             Ok(val) => assert_eq!(1.23, val),
             _ => assert!(false),
         }
-    }
-
-    #[test]
-    #[should_panic]
-    fn argument_fail() {
-        let args = vec![
-            "cli".to_string(),
-            "command".to_string(),
-            "args".to_string(),
-            "--bool".to_string(),
-            "--string".to_string(),
-        ];
-        let flags = vec![
-            Flag::new("bool", "", FlagType::Bool),
-            Flag::new("string", "", FlagType::String),
-        ];
-
-        Context::new(args, Some(flags));
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -32,7 +32,14 @@ impl Context {
                 for flag in flags {
                     if let Some(index) = flag.option_index(&parsed_args) {
                         parsed_args.remove(index);
+
                         if flag.flag_type != FlagType::Bool {
+                            if parsed_args.is_empty() {
+                                panic!(format!(
+                                    r#"Require to specify an argument for "--{}"."#,
+                                    flag.name
+                                ));
+                            }
                             parsed_args.remove(index);
                         }
                     }
@@ -194,5 +201,23 @@ mod tests {
             Some(val) => assert_eq!(1.23, val),
             _ => assert!(false),
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn argument_fail() {
+        let args = vec![
+            "cli".to_string(),
+            "command".to_string(),
+            "args".to_string(),
+            "--bool".to_string(),
+            "--string".to_string(),
+        ];
+        let flags = vec![
+            Flag::new("bool", "", FlagType::Bool),
+            Flag::new("string", "", FlagType::String),
+        ];
+
+        Context::new(args, Some(flags));
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -60,7 +60,7 @@ impl Context {
                 Ok(val) => Ok(val.to_owned()),
                 Err(e) => Err(e.to_owned()),
             },
-            None => Err(FlagError::NotFound),
+            None => Err(FlagError::Undefined),
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -34,6 +34,8 @@ impl Context {
                             None
                         };
                         v.push((flag.name.to_string(), flag.value(val)))
+                    } else {
+                        v.push((flag.name.to_string(), Err(FlagError::NotFound)))
                     }
                 }
                 Some(v)
@@ -105,7 +107,7 @@ impl Context {
         match self.result_flag_value(name) {
             Ok(FlagValue::String(val)) => Ok(val),
             Err(e) => Err(e),
-            _ => Err(FlagError::ArgumentError),
+            _ => Err(FlagError::TypeError),
         }
     }
 
@@ -127,7 +129,7 @@ impl Context {
         match self.result_flag_value(name) {
             Ok(FlagValue::Int(val)) => Ok(val),
             Err(e) => Err(e),
-            _ => Err(FlagError::ArgumentError),
+            _ => Err(FlagError::TypeError),
         }
     }
 
@@ -149,7 +151,7 @@ impl Context {
         match self.result_flag_value(name) {
             Ok(FlagValue::Float(val)) => Ok(val),
             Err(e) => Err(e),
-            _ => Err(FlagError::ArgumentError),
+            _ => Err(FlagError::TypeError),
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -106,15 +106,21 @@ impl Context {
     /// let context = Context::new(args, Some(vec![flag]));
     ///
     /// match context.string_flag("string") {
-    ///     Ok(s) => println!("{}", s),
-    ///     Err(_) => println!("Not found string...")
+    ///     Some(r) => match r {
+    ///         Ok(s) => println!("{}", s),
+    ///         Err(e) => println!("{}", e)
+    ///     },
+    ///     None => println!("Not found string...")
     /// }
     /// ```
     pub fn string_flag(&self, name: &str) -> Option<Result<String, String>> {
         match self.result_flag_value(name) {
-            Ok(FlagValue::String(val)) => Ok(val.to_string()),
-            Err(e) => Err(e.to_owned()),
-            _ => Err("".to_string()),
+            Some(r) => match r {
+                Ok(FlagValue::String(val)) => Some(Ok(val)),
+                Err(e) => Some(Err(e)),
+                _ => Some(Err("".to_string())),
+            },
+            None => None,
         }
     }
 
@@ -131,15 +137,21 @@ impl Context {
     /// let context = Context::new(args, Some(vec![flag]));
     ///
     /// match context.int_flag("int") {
-    ///     Ok(i) => println!("{}", i),
-    ///     Err(_) => println!("Not found int number...")
+    ///     Some(r) => match r {
+    ///         Ok(i) => println!("{}", i),
+    ///         Err(e) => println!("{}", e)
+    ///     }
+    ///     None => println!("Not found int number...")
     /// }
     /// ```
-    pub fn int_flag(&self, name: &str) -> Result<isize, String> {
+    pub fn int_flag(&self, name: &str) -> Option<Result<isize, String>> {
         match self.result_flag_value(name) {
-            Ok(FlagValue::Int(val)) => Ok(val),
-            Err(e) => Err(e.to_owned()),
-            _ => Err("hoge".to_string()),
+            Some(r) => match r {
+                Ok(FlagValue::Int(val)) => Some(Ok(val)),
+                Err(e) => Some(Err(e.to_owned())),
+                _ => Some(Err("".to_string())),
+            },
+            None => None,
         }
     }
 
@@ -156,15 +168,21 @@ impl Context {
     /// let context = Context::new(args, Some(vec![flag]));
     ///
     /// match context.float_flag("float") {
-    ///     Ok(f) => println!("{}", f),
-    ///     Err(_) => println!("Not found float number...")
+    ///     Some(r) => match r {
+    ///         Ok(f) => println!("{}", f),
+    ///         Err(e) => println!("{}", e)
+    ///     }
+    ///     None => println!("Not found float number...")
     /// }
     /// ```
-    pub fn float_flag(&self, name: &str) -> Result<f64, String> {
+    pub fn float_flag(&self, name: &str) -> Option<Result<f64, String>> {
         match self.result_flag_value(name) {
-            Ok(FlagValue::Float(val)) => Ok(val),
-            Err(e) => Err(e.to_owned()),
-            _ => Err("hoge".to_string()),
+            Some(r) => match r {
+                Ok(FlagValue::Float(val)) => Some(Ok(val)),
+                Err(e) => Some(Err(e.to_owned())),
+                _ => Some(Err("".to_string())),
+            },
+            None => None,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use std::error;
 use std::fmt;
 
-#[derive(PartialOrd, PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum FlagError {
     NotFound,
     Undefined,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,24 +1,32 @@
 use std::error;
 use std::fmt;
 
-struct ArgumentError {
-    name: String,
+#[derive(PartialOrd, PartialEq, Clone, Debug)]
+pub enum FlagError {
+    NotFound,
+    Undefined,
+    TypeError,
+    ArgumentError,
 }
 
-impl fmt::Display for ArgumentError {
+impl fmt::Display for FlagError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Argument error: {}", self.name)
+        match *self {
+            FlagError::NotFound => f.write_str("NotFound"),
+            FlagError::Undefined => f.write_str("Undefined"),
+            FlagError::TypeError => f.write_str("TypeError"),
+            FlagError::ArgumentError => f.write_str("ArgumentError"),
+        }
     }
 }
 
-impl error::Error for ArgumentError {
-    fn description(&self) -> &str {}
-
-    fn cause(&self) -> Option<&error::Error> {}
-}
-
-impl ArgumentError {
-    pub fn new<T: Into<String>>(name: T) -> Self {
-        Self { name: name.into() }
+impl error::Error for FlagError {
+    fn description(&self) -> &str {
+        match *self {
+            FlagError::NotFound => "Flag not found",
+            FlagError::Undefined => "Flag undefined",
+            FlagError::TypeError => "Value type mismatch",
+            FlagError::ArgumentError => "Illegal argument",
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ pub enum FlagError {
     NotFound,
     Undefined,
     TypeError,
+    ValueTypeError,
     ArgumentError,
 }
 
@@ -15,6 +16,7 @@ impl fmt::Display for FlagError {
             FlagError::NotFound => f.write_str("NotFound"),
             FlagError::Undefined => f.write_str("Undefined"),
             FlagError::TypeError => f.write_str("TypeError"),
+            FlagError::ValueTypeError => f.write_str("ValueTypeError"),
             FlagError::ArgumentError => f.write_str("ArgumentError"),
         }
     }
@@ -25,7 +27,8 @@ impl error::Error for FlagError {
         match *self {
             FlagError::NotFound => "Flag not found",
             FlagError::Undefined => "Flag undefined",
-            FlagError::TypeError => "Value type mismatch",
+            FlagError::TypeError => "Flag type mismatch",
+            FlagError::ValueTypeError => "Value type mismatch",
             FlagError::ArgumentError => "Illegal argument",
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,24 @@
+use std::error;
+use std::fmt;
+
+struct ArgumentError {
+    name: String,
+}
+
+impl fmt::Display for ArgumentError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Argument error: {}", self.name)
+    }
+}
+
+impl error::Error for ArgumentError {
+    fn description(&self) -> &str {}
+
+    fn cause(&self) -> Option<&error::Error> {}
+}
+
+impl ArgumentError {
+    pub fn new<T: Into<String>>(name: T) -> Self {
+        Self { name: name.into() }
+    }
+}

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -1,7 +1,7 @@
 /// `Flag` type.
 ///
 /// Option flag struct
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Flag {
     /// Flag name
     pub name: String,
@@ -14,7 +14,7 @@ pub struct Flag {
 }
 
 /// `FlagType` enum
-#[derive(PartialOrd, PartialEq, Clone)]
+#[derive(PartialOrd, PartialEq, Clone, Debug)]
 pub enum FlagType {
     Bool,
     String,
@@ -23,6 +23,7 @@ pub enum FlagType {
 }
 
 /// `FlagValue` enum
+#[derive(PartialOrd, PartialEq, Clone, Debug)]
 pub enum FlagValue {
     Bool(bool),
     String(String),
@@ -104,37 +105,41 @@ impl Flag {
     }
 
     /// Get flag value
-    pub fn value(&self, v: &[String]) -> Option<FlagValue> {
+    pub fn value(&self, v: Option<String>) -> Result<FlagValue, String> {
         match self.flag_type {
-            FlagType::Bool => match &self.alias {
-                Some(alias) => Some(FlagValue::Bool(
-                    v.contains(&format!("--{}", self.name))
-                        || alias.iter().any(|a| v.contains(&format!("-{}", a))),
+            FlagType::Bool => Ok(FlagValue::Bool(true)),
+            FlagType::String => match v {
+                Some(s) => Ok(FlagValue::String(s)),
+                None => Err(format!(
+                    "Arguments are required for the `--{}` flag.",
+                    self.name
                 )),
-                None => Some(FlagValue::Bool(v.contains(&format!("--{}", self.name)))),
             },
-            FlagType::String => match self.option_index(&v) {
-                Some(index) => Some(FlagValue::String(v[index + 1].to_owned())),
-                None => None,
-            },
-            FlagType::Int => match self.option_index(&v) {
-                Some(index) => Some(FlagValue::Int(
-                    v[index + 1].parse::<isize>().unwrap_or_else(|_| {
-                        panic!(format!("The value of `{}` flag should be int.", self.name))
-                    }),
+            FlagType::Int => match v {
+                Some(i) => match i.parse::<isize>() {
+                    Ok(i) => Ok(FlagValue::Int(i)),
+                    Err(_) => Err(format!(
+                        "The value of `--{}` flag should be int.",
+                        self.name
+                    )),
+                },
+                None => Err(format!(
+                    "Arguments are required for the `--{}` flag.",
+                    self.name
                 )),
-                None => None,
             },
-            FlagType::Float => match self.option_index(&v) {
-                Some(index) => Some(FlagValue::Float(
-                    v[index + 1].parse::<f64>().unwrap_or_else(|_| {
-                        panic!(format!(
-                            "The value of `{}` flag should be float.",
-                            self.name
-                        ))
-                    }),
+            FlagType::Float => match v {
+                Some(f) => match f.parse::<f64>() {
+                    Ok(f) => Ok(FlagValue::Float(f)),
+                    Err(_) => Err(format!(
+                        "The value of `--{}` flag should be float.",
+                        self.name
+                    )),
+                },
+                None => Err(format!(
+                    "Arguments are required for the `--{}` flag.",
+                    self.name
                 )),
-                None => None,
             },
         }
     }
@@ -195,8 +200,8 @@ mod tests {
             "--bool".to_string(),
         ];
 
-        match bool_flag.value(&v) {
-            Some(FlagValue::Bool(val)) => assert!(val),
+        match bool_flag.value(Some(v[3].to_owned())) {
+            Ok(FlagValue::Bool(val)) => assert!(val),
             _ => assert!(false),
         }
     }
@@ -212,8 +217,8 @@ mod tests {
             "test".to_string(),
         ];
 
-        match string_flag.value(&v) {
-            Some(FlagValue::String(val)) => assert_eq!("test".to_string(), val),
+        match string_flag.value(Some(v[4].to_owned())) {
+            Ok(FlagValue::String(val)) => assert_eq!("test".to_string(), val),
             _ => assert!(false),
         }
     }
@@ -229,8 +234,8 @@ mod tests {
             "100".to_string(),
         ];
 
-        match int_flag.value(&v) {
-            Some(FlagValue::Int(val)) => assert_eq!(100, val),
+        match int_flag.value(Some(v[4].to_owned())) {
+            Ok(FlagValue::Int(val)) => assert_eq!(100, val),
             _ => assert!(false),
         }
     }
@@ -246,8 +251,8 @@ mod tests {
             "1.23".to_string(),
         ];
 
-        match float_flag.value(&v) {
-            Some(FlagValue::Float(val)) => assert_eq!(1.23, val),
+        match float_flag.value(Some(v[4].to_owned())) {
+            Ok(FlagValue::Float(val)) => assert_eq!(1.23, val),
             _ => assert!(false),
         }
     }

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -132,14 +132,14 @@ impl Flag {
             FlagType::Int => match v {
                 Some(i) => match i.parse::<isize>() {
                     Ok(i) => Ok(FlagValue::Int(i)),
-                    Err(_) => Err(FlagError::TypeError),
+                    Err(_) => Err(FlagError::ValueTypeError),
                 },
                 None => Err(FlagError::ArgumentError),
             },
             FlagType::Float => match v {
                 Some(f) => match f.parse::<f64>() {
                     Ok(f) => Ok(FlagValue::Float(f)),
-                    Err(_) => Err(FlagError::TypeError),
+                    Err(_) => Err(FlagError::ValueTypeError),
                 },
                 None => Err(FlagError::ArgumentError),
             },

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -16,7 +16,7 @@ pub struct Flag {
 }
 
 /// `FlagType` enum
-#[derive(PartialOrd, PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum FlagType {
     Bool,
     String,
@@ -25,7 +25,7 @@ pub enum FlagType {
 }
 
 /// `FlagValue` enum
-#[derive(PartialOrd, PartialEq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum FlagValue {
     Bool(bool),
     String(String),

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -1,3 +1,5 @@
+use crate::error::FlagError;
+
 /// `Flag` type.
 ///
 /// Option flag struct
@@ -120,41 +122,26 @@ impl Flag {
     }
 
     /// Get flag value
-    pub fn value(&self, v: Option<String>) -> Result<FlagValue, String> {
+    pub fn value(&self, v: Option<String>) -> Result<FlagValue, FlagError> {
         match self.flag_type {
             FlagType::Bool => Ok(FlagValue::Bool(true)),
             FlagType::String => match v {
                 Some(s) => Ok(FlagValue::String(s)),
-                None => Err(format!(
-                    "Arguments are required for the `--{}` flag.",
-                    self.name
-                )),
+                None => Err(FlagError::ArgumentError),
             },
             FlagType::Int => match v {
                 Some(i) => match i.parse::<isize>() {
                     Ok(i) => Ok(FlagValue::Int(i)),
-                    Err(_) => Err(format!(
-                        "The value of `--{}` flag should be int.",
-                        self.name
-                    )),
+                    Err(_) => Err(FlagError::TypeError),
                 },
-                None => Err(format!(
-                    "Arguments are required for the `--{}` flag.",
-                    self.name
-                )),
+                None => Err(FlagError::ArgumentError),
             },
             FlagType::Float => match v {
                 Some(f) => match f.parse::<f64>() {
                     Ok(f) => Ok(FlagValue::Float(f)),
-                    Err(_) => Err(format!(
-                        "The value of `--{}` flag should be float.",
-                        self.name
-                    )),
+                    Err(_) => Err(FlagError::TypeError),
                 },
-                None => Err(format!(
-                    "Arguments are required for the `--{}` flag.",
-                    self.name
-                )),
+                None => Err(FlagError::ArgumentError),
             },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod app;
 pub mod color;
 mod command;
 mod context;
+pub mod error;
 mod flag;
 
 pub use action::Action;


### PR DESCRIPTION
close #48 

```rust
use seahorse::{error::FlagError, Context};

fn action(c: &Context) {
    match c.int_flag("int") {
        Ok(i) => println!("{}", i),
        Err(e) => match e {
            FlagError::ArgumentError => println!("argument error"),
            FlagError::TypeError => println!("type error"),
            FlagError::ValueTypeError => println!("value type error"),
            FlagError::Undefined => println!("undefined"),
            FlagError::NotFound => println!("not found"),
        },
    }
}
```