### PR TITLE
Use ? operator

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -104,9 +104,9 @@ impl Context {
     /// }
     /// ```
     pub fn string_flag(&self, name: &str) -> Result<String, FlagError> {
-        match self.result_flag_value(name) {
-            Ok(FlagValue::String(val)) => Ok(val),
-            Err(e) => Err(e),
+        let r = self.result_flag_value(name)?;
+        match r {
+            FlagValue::String(val) => Ok(val),
             _ => Err(FlagError::TypeError),
         }
     }
@@ -126,9 +126,9 @@ impl Context {
     /// }
     /// ```
     pub fn int_flag(&self, name: &str) -> Result<isize, FlagError> {
-        match self.result_flag_value(name) {
-            Ok(FlagValue::Int(val)) => Ok(val),
-            Err(e) => Err(e),
+        let r = self.result_flag_value(name)?;
+        match r {
+            FlagValue::Int(val) => Ok(val),
             _ => Err(FlagError::TypeError),
         }
     }
@@ -148,9 +148,9 @@ impl Context {
     /// }
     /// ```
     pub fn float_flag(&self, name: &str) -> Result<f64, FlagError> {
-        match self.result_flag_value(name) {
-            Ok(FlagValue::Float(val)) => Ok(val),
-            Err(e) => Err(e),
+        let r = self.result_flag_value(name)?;
+        match r {
+            FlagValue::Float(val) => Ok(val),
             _ => Err(FlagError::TypeError),
         }
     }


### PR DESCRIPTION
If `Result` value returned from a subroutine is passed as the return value of the function, you can use `?` operator.
This change will make `match` expression easier  to understand.

FYI: https://qiita.com/kanna/items/a0c10a0563573d5b2ed0

and some tests are added.