### PR TITLE
Fix panic macro

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -138,10 +138,7 @@ impl App {
                 .iter()
                 .any(|registered| registered.name == command.name)
             {
-                panic!(
-                    "{}",
-                    format!(r#"Command name "{}" is already registered."#, command.name)
-                );
+                panic!(r#"Command name "{}" is already registered."#, command.name);
             }
             (*commands).push(command);
         } else {

--- a/src/app.rs
+++ b/src/app.rs
@@ -138,10 +138,10 @@ impl App {
                 .iter()
                 .any(|registered| registered.name == command.name)
             {
-                panic!(format!(
-                    r#"Command name "{}" is already registered."#,
-                    command.name
-                ));
+                panic!(
+                    "{}",
+                    format!(r#"Command name "{}" is already registered."#, command.name)
+                );
             }
             (*commands).push(command);
         } else {

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -48,29 +48,20 @@ impl Flag {
         let name = name.into();
         if name.starts_with('-') {
             panic!(
-                "{}",
-                format!(
-                    r#""{}" is invalid flag name. Flag name cannnot start with "-"."#,
-                    name
-                )
+                r#""{}" is invalid flag name. Flag name cannnot start with "-"."#,
+                name
             )
         }
         if name.contains('=') {
             panic!(
-                "{}",
-                format!(
-                    r#""{}" is invalid flag name. Flag name cannnot contain "="."#,
-                    name
-                )
+                r#""{}" is invalid flag name. Flag name cannnot contain "="."#,
+                name
             )
         }
         if name.contains(' ') {
             panic!(
-                "{}",
-                format!(
-                    r#""{}" is invalid flag name. Flag name cannnot contain whitespaces."#,
-                    name
-                )
+                r#""{}" is invalid flag name. Flag name cannnot contain whitespaces."#,
+                name
             )
         }
 

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -47,22 +47,31 @@ impl Flag {
     pub fn new<T: Into<String>>(name: T, flag_type: FlagType) -> Self {
         let name = name.into();
         if name.starts_with('-') {
-            panic!(format!(
-                r#""{}" is invalid flag name. Flag name cannnot start with "-"."#,
-                name
-            ))
+            panic!(
+                "{}",
+                format!(
+                    r#""{}" is invalid flag name. Flag name cannnot start with "-"."#,
+                    name
+                )
+            )
         }
         if name.contains('=') {
-            panic!(format!(
-                r#""{}" is invalid flag name. Flag name cannnot contain "="."#,
-                name
-            ))
+            panic!(
+                "{}",
+                format!(
+                    r#""{}" is invalid flag name. Flag name cannnot contain "="."#,
+                    name
+                )
+            )
         }
         if name.contains(' ') {
-            panic!(format!(
-                r#""{}" is invalid flag name. Flag name cannnot contain whitespaces."#,
-                name
-            ))
+            panic!(
+                "{}",
+                format!(
+                    r#""{}" is invalid flag name. Flag name cannnot contain whitespaces."#,
+                    name
+                )
+            )
         }
 
         Self {


### PR DESCRIPTION
Since edition 2021, a warning will be issued if you do not pass a string literal as an argument of the `panic!`.