### PR TITLE
Allow actions to return ActionResult values to represent errors

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -11,4 +11,9 @@ use crate::Context;
 ///     println!("{:?}", c.args);
 /// };
 /// ```
-pub type Action = fn(&Context) -> std::fmt::Result;
+pub type Action = fn(&Context) -> Result<(), CommandError>;
+
+#[derive(Debug)]
+pub struct CommandError {
+    pub message: String,
+}

--- a/src/action.rs
+++ b/src/action.rs
@@ -13,14 +13,16 @@ use crate::Context;
 /// ```
 pub type Action = fn(&Context);
 
-pub type ActionWithResult = fn(&Context) -> Result<(), CommandError>;
+pub type ActionWithResult = fn(&Context) -> ActionResult;
+
+pub type ActionResult = Result<(), ActionError>;
 
 #[derive(Debug)]
-pub struct CommandError {
+pub struct ActionError {
     pub message: String,
 }
 
-pub fn fail(e: CommandError) {
+pub fn fail(e: ActionError) {
     eprintln!("Error: {}", e.message);
     std::process::exit(-1);
 }

--- a/src/action.rs
+++ b/src/action.rs
@@ -17,3 +17,8 @@ pub type Action = fn(&Context) -> Result<(), CommandError>;
 pub struct CommandError {
     pub message: String,
 }
+
+pub fn fail(e: CommandError) {
+    eprintln!("Error: {}", e.message);
+    std::process::exit(-1);
+}

--- a/src/action.rs
+++ b/src/action.rs
@@ -11,7 +11,9 @@ use crate::Context;
 ///     println!("{:?}", c.args);
 /// };
 /// ```
-pub type Action = fn(&Context) -> Result<(), CommandError>;
+pub type Action = fn(&Context);
+
+pub type ActionWithResult = fn(&Context) -> Result<(), CommandError>;
 
 #[derive(Debug)]
 pub struct CommandError {

--- a/src/action.rs
+++ b/src/action.rs
@@ -11,4 +11,4 @@ use crate::Context;
 ///     println!("{:?}", c.args);
 /// };
 /// ```
-pub type Action = fn(&Context);
+pub type Action = fn(&Context) -> std::fmt::Result;

--- a/src/app.rs
+++ b/src/app.rs
@@ -218,11 +218,14 @@ impl App {
                         self.help();
                         return;
                     }
-                    action(&Context::new(
+                    match action(&Context::new(
                         args[1..].to_vec(),
                         self.flags.clone(),
                         self.help_text(),
-                    ));
+                    )) {
+                        Ok(_) => println!("ok"),
+                        Err(e) => println!("err {}", e),
+                    }
                 }
                 None => self.help(),
             },

--- a/src/app.rs
+++ b/src/app.rs
@@ -224,7 +224,7 @@ impl App {
                         self.help_text(),
                     )) {
                         Ok(_) => println!("ok"),
-                        Err(e) => println!("err {}", e),
+                        Err(e) => println!("err {}", e.message),
                     }
                 }
                 None => self.help(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,4 @@
+use crate::action::fail;
 use crate::{Action, Command, Context, Flag, FlagType, Help};
 
 /// Multiple action application entry point
@@ -223,8 +224,8 @@ impl App {
                         self.flags.clone(),
                         self.help_text(),
                     )) {
-                        Ok(_) => println!("ok"),
-                        Err(e) => println!("err {}", e.message),
+                        Ok(_) => (),
+                        Err(e) => fail(e),
                     }
                 }
                 None => self.help(),

--- a/src/command.rs
+++ b/src/command.rs
@@ -242,7 +242,7 @@ impl Command {
                             self.help_text(),
                         )) {
                             Ok(_) => (),
-                            Err(e) => eprintln!("Error {}", e.message),
+                            Err(e) => fail(e),
                         }
                     }
                     None => self.help(),

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,4 @@
+use crate::action::fail;
 use crate::{Action, Context, Flag, FlagType, Help};
 
 /// Application command type
@@ -222,8 +223,8 @@ impl Command {
                             self.flags.clone(),
                             self.help_text(),
                         )) {
-                            Ok(_) => println!("ok"),
-                            Err(e) => println!("err {}", e.message),
+                            Ok(_) => (),
+                            Err(e) => eprintln!("Error {}", e.message),
                         }
                     }
                     None => self.help(),
@@ -240,8 +241,8 @@ impl Command {
                         self.flags.clone(),
                         self.help_text(),
                     )) {
-                        Ok(_) => println!("ok"),
-                        Err(e) => println!("err {}", e.message),
+                        Ok(_) => (),
+                        Err(e) => fail(e),
                     }
                 }
                 None => self.help(),

--- a/src/command.rs
+++ b/src/command.rs
@@ -217,11 +217,14 @@ impl Command {
                             self.help();
                             return;
                         }
-                        action(&Context::new(
+                        match action(&Context::new(
                             args.to_vec(),
                             self.flags.clone(),
                             self.help_text(),
-                        ));
+                        )) {
+                            Ok(_) => println!("ok"),
+                            Err(e) => println!("err {}", e),
+                        }
                     }
                     None => self.help(),
                 },
@@ -232,11 +235,14 @@ impl Command {
                         self.help();
                         return;
                     }
-                    action(&Context::new(
+                    match action(&Context::new(
                         args.to_vec(),
                         self.flags.clone(),
                         self.help_text(),
-                    ));
+                    )) {
+                        Ok(_) => println!("ok"),
+                        Err(e) => println!("err {}", e),
+                    }
                 }
                 None => self.help(),
             },

--- a/src/command.rs
+++ b/src/command.rs
@@ -223,7 +223,7 @@ impl Command {
                             self.help_text(),
                         )) {
                             Ok(_) => println!("ok"),
-                            Err(e) => println!("err {}", e),
+                            Err(e) => println!("err {}", e.message),
                         }
                     }
                     None => self.help(),
@@ -241,7 +241,7 @@ impl Command {
                         self.help_text(),
                     )) {
                         Ok(_) => println!("ok"),
-                        Err(e) => println!("err {}", e),
+                        Err(e) => println!("err {}", e.message),
                     }
                 }
                 None => self.help(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod flag;
 mod help;
 
 pub use action::Action;
+pub use action::ActionWithResult;
 pub use action::CommandError;
 pub use app::App;
 pub use command::Command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod flag;
 mod help;
 
 pub use action::Action;
+pub use action::CommandError;
 pub use app::App;
 pub use command::Command;
 pub use context::Context;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,7 @@ pub mod error;
 mod flag;
 mod help;
 
-pub use action::Action;
-pub use action::ActionWithResult;
-pub use action::CommandError;
+pub use action::{Action, ActionWithResult, ActionResult, ActionError};
 pub use app::App;
 pub use command::Command;
 pub use context::Context;


### PR DESCRIPTION
Fixes #75 

This is currently a draft, but all comments are welcome.

This PR will contain a nonbreaking change that adds support for a new action field, tentatively called `action_with_result`, that can be specified instead of `action` for `Command` and `App` structs. These fields would take functions that return a new `Result` type that include errors that can be checked in the Seahorse calling code.

todo: 
- restore support for the original `action` handling
- generate runtime errors if users specify both `action` and `action_with_result`
- update tests (fix original tests and verify the new capability)