### PR TITLE
Update top_level_error_handling.rs

### DIFF
--- a/examples/top_level_error_handling.rs
+++ b/examples/top_level_error_handling.rs
@@ -24,7 +24,7 @@ fn main() {
 
     match app.run_with_result(args) {
         Ok(_) => println!("OK"),
-        Err(e) => println!("{}", e),
+        Err(e) => println!("{:?}", e),
     };
 }
 


### PR DESCRIPTION
`ActionError` doesn't implement `std::fmt::Display` the trait `std::fmt::Display` is not implemented for `ActionError`