### PR TITLE
add support for repeated flags

### DIFF
--- a/examples/multiple_flags.rs
+++ b/examples/multiple_flags.rs
@@ -8,7 +8,7 @@ fn main() {
     let app = App::new(name)
         .author(env!("CARGO_PKG_AUTHORS"))
         .description(env!("CARGO_PKG_DESCRIPTION"))
-        .usage("single_app [args]")
+        .usage("multiple_flags [args]")
         .version(env!("CARGO_PKG_VERSION"))
         .action(action)
         .flag(

--- a/examples/multiple_flags.rs
+++ b/examples/multiple_flags.rs
@@ -1,0 +1,55 @@
+use seahorse::{App, Context, Flag, FlagType};
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let name = "multiple_flags";
+
+    let app = App::new(name)
+        .author(env!("CARGO_PKG_AUTHORS"))
+        .description(env!("CARGO_PKG_DESCRIPTION"))
+        .usage("single_app [args]")
+        .version(env!("CARGO_PKG_VERSION"))
+        .action(action)
+        .flag(
+            Flag::new("verbose", FlagType::Bool)
+                .description("Increase verbosity level by repeat --verbose(-v) multiple times")
+                .alias("v")
+                .multiple(),
+        )
+        .flag(
+            Flag::new("header", FlagType::String)
+                .description("Set header of the request, argument can be repeated")
+                .alias("H")
+                .multiple(),
+        )
+        .flag(
+            Flag::new("offset", FlagType::Uint)
+                .description("Counter offset, argument can be repeated")
+                .alias("o")
+                .multiple(),
+        );
+
+    app.run(args);
+}
+
+fn action(c: &Context) {
+    // Count the number of times the flag was passed
+    let verbosity_level = c.bool_flag_vec("verbose").iter().flatten().count();
+
+    println!("Verbosity level: {}", verbosity_level);
+
+    // Print only the first 'header' flag passed
+    println!("Headers: {:?}", c.string_flag("header"));
+
+    // To access all 'header' flags passed, if the flag is not marked as multiple the
+    // vector will only contain one element, the rest will be ignored.
+    for header in c.string_flag_vec("header") {
+        println!("Header: {:?}", header);
+    }
+
+    // Access all 'offset' flags passed
+    for offset in c.uint_flag_vec("offset") {
+        println!("offset: {:?}", offset);
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -113,6 +113,33 @@ impl Context {
         }
     }
 
+    /// Get bool flags for repeated flags
+    ///
+    /// Example
+    ///
+    /// ```
+    /// use seahorse::Context;
+    ///
+    /// fn action(c: &Context) {
+    ///     for b in c.bool_flag_vec("bool") {
+    ///         match b {
+    ///            Ok(b) => println!("{}", b),
+    ///            Err(e) => println!("{}", e)
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    pub fn bool_flag_vec(&self, name: &str) -> Vec<Result<bool, FlagError>> {
+        let r = self.result_flag_value_vec(name);
+
+        r.iter()
+            .map(|r| match r {
+                Ok(FlagValue::Bool(val)) => Ok(val.clone()),
+                _ => Err(FlagError::TypeError),
+            })
+            .collect::<Vec<_>>()
+    }
+
     /// Get string flag
     ///
     /// Example

--- a/src/context.rs
+++ b/src/context.rs
@@ -41,7 +41,7 @@ impl Context {
                                 break;
                             }
                         } else {
-                            if !found_flag {
+                            if !found_flag || !flag.multiple {
                                 v.push((flag.name.to_string(), Err(FlagError::NotFound)));
                             }
                             break;
@@ -135,6 +135,7 @@ impl Context {
         r.iter()
             .map(|r| match r {
                 Ok(FlagValue::Bool(val)) => Ok(val.clone()),
+                Err(FlagError::NotFound) => Err(FlagError::NotFound),
                 _ => Err(FlagError::TypeError),
             })
             .collect::<Vec<_>>()
@@ -184,6 +185,7 @@ impl Context {
         r.iter()
             .map(|r| match r {
                 Ok(FlagValue::String(val)) => Ok(val.clone()),
+                Err(FlagError::NotFound) => Err(FlagError::NotFound),
                 _ => Err(FlagError::TypeError),
             })
             .collect::<Vec<_>>()
@@ -233,6 +235,7 @@ impl Context {
         r.iter()
             .map(|r| match r {
                 Ok(FlagValue::Int(val)) => Ok(val.clone()),
+                Err(FlagError::NotFound) => Err(FlagError::NotFound),
                 _ => Err(FlagError::TypeError),
             })
             .collect::<Vec<_>>()
@@ -282,6 +285,7 @@ impl Context {
         r.iter()
             .map(|r| match r {
                 Ok(FlagValue::Uint(val)) => Ok(val.clone()),
+                Err(FlagError::NotFound) => Err(FlagError::NotFound),
                 _ => Err(FlagError::TypeError),
             })
             .collect::<Vec<_>>()
@@ -333,6 +337,7 @@ impl Context {
         r.iter()
             .map(|r| match *r {
                 Ok(FlagValue::Float(val)) => Ok(val),
+                Err(FlagError::NotFound) => Err(FlagError::NotFound),
                 _ => Err(FlagError::TypeError),
             })
             .collect::<Vec<_>>()

--- a/src/context.rs
+++ b/src/context.rs
@@ -77,12 +77,17 @@ impl Context {
     }
 
     // Get flag values for repeated flags
-    fn result_flag_value_vec(&self, name: &str) -> Vec::<Result<FlagValue, FlagError>> {
-        self.flags.as_ref().unwrap().iter().filter(|flag| flag.0 == name)
+    fn result_flag_value_vec(&self, name: &str) -> Vec<Result<FlagValue, FlagError>> {
+        self.flags
+            .as_ref()
+            .unwrap()
+            .iter()
+            .filter(|flag| flag.0 == name)
             .map(|f| match &f.1 {
-            Ok(val) => Ok(val.to_owned()),
-            Err(e) => Err(e.to_owned()),
-        }).collect::<Vec<_>>()
+                Ok(val) => Ok(val.to_owned()),
+                Err(e) => Err(e.to_owned()),
+            })
+            .collect::<Vec<_>>()
     }
 
     /// Get bool flag
@@ -149,13 +154,12 @@ impl Context {
     pub fn string_flag_vec(&self, name: &str) -> Vec<Result<String, FlagError>> {
         let r = self.result_flag_value_vec(name);
 
-        r.iter().map(|r|
-        {
-            match r {
+        r.iter()
+            .map(|r| match r {
                 Ok(FlagValue::String(val)) => Ok(val.clone()),
                 _ => Err(FlagError::TypeError),
-            }
-        }).collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>()
     }
 
     /// Get int flag
@@ -199,13 +203,12 @@ impl Context {
     pub fn int_flag_vec(&self, name: &str) -> Vec<Result<isize, FlagError>> {
         let r = self.result_flag_value_vec(name);
 
-        r.iter().map(|r|
-        {
-            match r {
+        r.iter()
+            .map(|r| match r {
                 Ok(FlagValue::Int(val)) => Ok(val.clone()),
                 _ => Err(FlagError::TypeError),
-            }
-        }).collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>()
     }
 
     /// Get Uint flag
@@ -249,13 +252,12 @@ impl Context {
     pub fn uint_flag_vec(&self, name: &str) -> Vec<Result<usize, FlagError>> {
         let r = self.result_flag_value_vec(name);
 
-        r.iter().map(|r|
-        {
-            match r {
+        r.iter()
+            .map(|r| match r {
                 Ok(FlagValue::Uint(val)) => Ok(val.clone()),
                 _ => Err(FlagError::TypeError),
-            }
-        }).collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>()
     }
 
     /// Get float flag
@@ -301,13 +303,12 @@ impl Context {
 
         // I would like to map the Result<FlagValue, FlagError> to Result<f64, FlagError>
 
-        r.iter().map(|r|
-        {
-            match *r {
+        r.iter()
+            .map(|r| match *r {
                 Ok(FlagValue::Float(val)) => Ok(val),
                 _ => Err(FlagError::TypeError),
-            }
-        }).collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>()
     }
 
     /// Display help

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -13,6 +13,8 @@ pub struct Flag {
     pub flag_type: FlagType,
     /// Flag alias
     pub alias: Option<Vec<String>>,
+    /// Multiple occurrence
+    pub multiple: bool,
 }
 
 /// `FlagType` enum
@@ -72,6 +74,7 @@ impl Flag {
             description: None,
             flag_type,
             alias: None,
+            multiple: false,
         }
     }
 
@@ -87,6 +90,21 @@ impl Flag {
     /// ```
     pub fn description<T: Into<String>>(mut self, description: T) -> Self {
         self.description = Some(description.into());
+        self
+    }
+
+    /// Set multiple flag
+    ///
+    /// Example
+    ///
+    /// ```
+    /// use seahorse::{Flag, FlagType};
+    ///
+    /// let bool_flag = Flag::new("bool", FlagType::Bool)
+    ///    .multiple();
+    /// ```
+    pub fn multiple(mut self) -> Self {
+        self.multiple = true;
         self
     }
 
@@ -281,6 +299,25 @@ mod tests {
 
         match float_flag.value(Some(v[4].to_owned())) {
             Ok(FlagValue::Float(val)) => assert_eq!(1.23, val),
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn multiple_string_flag_test() {
+        let string_flag = Flag::new("string", FlagType::String);
+        let v = vec![
+            "cli".to_string(),
+            "command".to_string(),
+            "args".to_string(),
+            "--string".to_string(),
+            "test".to_string(),
+            "--string".to_string(),
+            "test2".to_string(),
+        ];
+
+        match string_flag.value(Some(v[4].to_owned())) {
+            Ok(FlagValue::String(val)) => assert_eq!("test".to_string(), val),
             _ => assert!(false),
         }
     }


### PR DESCRIPTION
If a flag is defined with 'multiple()' - we collect the flag repeatedly. I have extended the `Context` with function to fetchs all occurence of a flag. E.g. `string_flag_vec` which return a vector of `Result<String, FlagError>` similar with the other flag types.