### PR TITLE
Align flag alias with normal use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             allow_failure: false
           - build: msrv
             os: ubuntu-latest
-            rust: 1.35.0
+            rust: 1.67.0
             allow_failure: false
     steps:
       - uses: actions/checkout@master

--- a/src/app.rs
+++ b/src/app.rs
@@ -164,7 +164,7 @@ impl App {
     /// let app = App::new("cli")
     ///     .action(action);
     /// ```
-    ///     
+    ///
     /// # Panics
     ///
     /// You cannot set both action and action_with_result.
@@ -366,11 +366,23 @@ impl App {
                 let alias = match &f.alias {
                     Some(alias) => alias
                         .iter()
+                        .filter(|&a| a.len() == 1)
                         .map(|a| format!("-{}", a))
                         .collect::<Vec<String>>()
                         .join(", "),
                     None => String::new(),
                 };
+
+                let long_alias = match &f.alias {
+                    Some(alias) => alias
+                        .iter()
+                        .filter(|a| a.len() > 1)
+                        .map(|a| format!("--{}", a))
+                        .collect::<Vec<String>>()
+                        .join(", "),
+                    None => String::new(),
+                };
+
                 let val = match f.flag_type {
                     FlagType::Int => int_val,
                     FlagType::Float => float_val,
@@ -379,9 +391,17 @@ impl App {
                 };
 
                 let help = if alias.is_empty() {
-                    format!("--{} {}", f.name, val)
+                    if long_alias.is_empty() {
+                        format!("--{} {}", f.name, val)
+                    } else {
+                        format!("{}, --{}, {}", long_alias, f.name, val)
+                    }
                 } else {
-                    format!("{}, --{} {}", alias, f.name, val)
+                    if long_alias.is_empty() {
+                        format!("{}, --{} {}", alias, f.name, val)
+                    } else {
+                        format!("{}, {}, --{} {}", alias, long_alias, f.name, val)
+                    }
                 };
 
                 (help, f.description.clone())

--- a/src/app.rs
+++ b/src/app.rs
@@ -339,9 +339,22 @@ impl App {
     /// Split arg with "=" to unify arg notations.
     /// --flag=value => ["--flag", "value"]
     /// --flag value => ["--flag", "value"]
+    /// -abe => ["-a", "-b", "-e"]
+    /// -abef=32 => ["-a", "-b", "-e", "-f", "32"]
     fn normalized_args(raw_args: Vec<String>) -> Vec<String> {
         raw_args.iter().fold(Vec::<String>::new(), |mut acc, cur| {
-            if cur.starts_with('-') && cur.contains('=') {
+            if cur.starts_with('-') && !cur.starts_with("--") {
+                if cur.contains('=') {
+                    let splitted_flag: Vec<String> =
+                        cur.splitn(2, '=').map(|s| s.to_owned()).collect();
+                    let short_named = splitted_flag[0].chars().skip(1).map(|c| format!("-{}", c));
+                    acc.append(&mut short_named.collect());
+                    acc.append(&mut splitted_flag[1..].to_vec());
+                } else {
+                    let short_named = cur.chars().skip(1).map(|c| format!("-{}", c));
+                    acc.append(&mut short_named.collect());
+                }
+            } else if cur.starts_with('-') && cur.contains('=') {
                 let mut splitted_flag: Vec<String> =
                     cur.splitn(2, '=').map(|s| s.to_owned()).collect();
                 acc.append(&mut splitted_flag);

--- a/src/command.rs
+++ b/src/command.rs
@@ -349,11 +349,23 @@ impl Command {
                 let alias = match &f.alias {
                     Some(alias) => alias
                         .iter()
+                        .filter(|a| a.len() == 1)
                         .map(|a| format!("-{}", a))
                         .collect::<Vec<String>>()
                         .join(", "),
                     None => String::new(),
                 };
+
+                let long_alias = match &f.alias {
+                    Some(alias) => alias
+                        .iter()
+                        .filter(|a| a.len() > 1)
+                        .map(|a| format!("--{}", a))
+                        .collect::<Vec<String>>()
+                        .join(", "),
+                    None => String::new(),
+                };
+
                 let val = match f.flag_type {
                     FlagType::Int => int_val,
                     FlagType::Float => float_val,
@@ -362,9 +374,17 @@ impl Command {
                 };
 
                 let help = if alias.is_empty() {
-                    format!("--{} {}", f.name, val)
+                    if long_alias.is_empty() {
+                        format!("--{} {}", f.name, val)
+                    } else {
+                        format!("{}, --{}, {}", long_alias, f.name, val)
+                    }
                 } else {
-                    format!("{}, --{} {}", alias, f.name, val)
+                    if long_alias.is_empty() {
+                        format!("{}, --{} {}", alias, f.name, val)
+                    } else {
+                        format!("{}, {}, --{} {}", alias, long_alias, f.name, val)
+                    }
                 };
 
                 (help, f.description.clone())

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,4 @@
+use crate::utils::normalized_args;
 use crate::{Action, ActionWithResult, Context, Flag, FlagType, Help};
 use std::error::Error;
 
@@ -242,34 +243,10 @@ impl Command {
         }
     }
 
-    fn normalized_args(raw_args: Vec<String>) -> Vec<String> {
-        raw_args.iter().fold(Vec::<String>::new(), |mut acc, cur| {
-            if cur.starts_with('-') && !cur.starts_with("--") {
-                if cur.contains('=') {
-                    let splitted_flag: Vec<String> =
-                        cur.splitn(2, '=').map(|s| s.to_owned()).collect();
-                    let short_named = splitted_flag[0].chars().skip(1).map(|c| format!("-{}", c));
-                    acc.append(&mut short_named.collect());
-                    acc.append(&mut splitted_flag[1..].to_vec());
-                } else {
-                    let short_named = cur.chars().skip(1).map(|c| format!("-{}", c));
-                    acc.append(&mut short_named.collect());
-                }
-            } else if cur.starts_with('-') && cur.contains('=') {
-                let mut splitted_flag: Vec<String> =
-                    cur.splitn(2, '=').map(|s| s.to_owned()).collect();
-                acc.append(&mut splitted_flag);
-            } else {
-                acc.push(cur.to_owned());
-            }
-            acc
-        })
-    }
-
     /// Run command
     /// Call this function only from `App`
     pub fn run_with_result(&self, args: Vec<String>) -> Result<(), Box<dyn Error>> {
-        let args = Self::normalized_args(args);
+        let args = normalized_args(args);
 
         match args.split_first() {
             Some((cmd, args_v)) => match self.select_command(cmd) {

--- a/src/command.rs
+++ b/src/command.rs
@@ -244,7 +244,18 @@ impl Command {
 
     fn normalized_args(raw_args: Vec<String>) -> Vec<String> {
         raw_args.iter().fold(Vec::<String>::new(), |mut acc, cur| {
-            if cur.starts_with('-') && cur.contains('=') {
+            if cur.starts_with('-') && !cur.starts_with("--") {
+                if cur.contains('=') {
+                    let splitted_flag: Vec<String> =
+                        cur.splitn(2, '=').map(|s| s.to_owned()).collect();
+                    let short_named = splitted_flag[0].chars().skip(1).map(|c| format!("-{}", c));
+                    acc.append(&mut short_named.collect());
+                    acc.append(&mut splitted_flag[1..].to_vec());
+                } else {
+                    let short_named = cur.chars().skip(1).map(|c| format!("-{}", c));
+                    acc.append(&mut short_named.collect());
+                }
+            } else if cur.starts_with('-') && cur.contains('=') {
                 let mut splitted_flag: Vec<String> =
                     cur.splitn(2, '=').map(|s| s.to_owned()).collect();
                 acc.append(&mut splitted_flag);

--- a/src/context.rs
+++ b/src/context.rs
@@ -362,6 +362,7 @@ impl Context {
 #[cfg(test)]
 mod tests {
     use crate::error::FlagError;
+    use crate::utils::normalized_args;
     use crate::{Context, Flag, FlagType};
 
     #[test]
@@ -377,10 +378,12 @@ mod tests {
             "100".to_string(),
             "--uint".to_string(),
             "1234567654321".to_string(),
-            "--float".to_string(),
+            "--float_alias".to_string(),
             "1.23".to_string(),
             "--float".to_string(),
             "1.44".to_string(),
+            "-ga".to_string(),
+            "atest".to_string(),
             "--invalid_float".to_string(),
             "invalid".to_string(),
         ];
@@ -389,17 +392,23 @@ mod tests {
             Flag::new("string", FlagType::String),
             Flag::new("int", FlagType::Int),
             Flag::new("uint", FlagType::Uint),
-            Flag::new("float", FlagType::Float).multiple(),
+            Flag::new("float", FlagType::Float)
+                .multiple()
+                .alias("float_alias"),
+            Flag::new("gbool", FlagType::Bool).alias("g"),
+            Flag::new("alias", FlagType::String).alias("a"),
             Flag::new("invalid_float", FlagType::Float),
             Flag::new("not_specified", FlagType::String),
         ];
-        let context = Context::new(args, Some(flags), "".to_string());
+        let context = Context::new(normalized_args(args), Some(flags), "".to_string());
 
         assert_eq!(context.bool_flag("bool"), true);
         assert_eq!(context.string_flag("string"), Ok("test".to_string()));
         assert_eq!(context.int_flag("int"), Ok(100));
         assert_eq!(context.uint_flag("uint"), Ok(1234567654321));
         assert_eq!(context.float_flag("float"), Ok(1.23));
+        assert_eq!(context.bool_flag("gbool"), true);
+        assert_eq!(context.string_flag("alias"), Ok("atest".to_string()));
 
         // string value arg, string flag, used as int
         assert_eq!(context.int_flag("string"), Err(FlagError::TypeError));

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -135,7 +135,14 @@ impl Flag {
     pub fn option_index(&self, v: &[String]) -> Option<usize> {
         match &self.alias {
             Some(alias) => v.iter().position(|r| {
-                r == &format!("--{}", &self.name) || alias.iter().any(|a| r == &format!("-{}", a))
+                r == &format!("--{}", &self.name)
+                    || alias.iter().any(|a| {
+                        if a.len() > 1 {
+                            r == &format!("--{}", a)
+                        } else {
+                            r == &format!("-{}", a)
+                        }
+                    })
             }),
             None => v.iter().position(|r| r == &format!("--{}", &self.name)),
         }

--- a/src/flag.rs
+++ b/src/flag.rs
@@ -184,15 +184,16 @@ mod tests {
             "cli".to_string(),
             "command".to_string(),
             "-a".to_string(),
+            "--ag".to_string(),
             "--bool".to_string(),
             "-c".to_string(),
         ];
         {
             let f = Flag::new("bool", FlagType::Bool);
-            assert_eq!(f.option_index(&v), Some(3));
+            assert_eq!(f.option_index(&v), Some(4));
         }
         {
-            let f = Flag::new("age", FlagType::Bool).alias("a");
+            let f = Flag::new("age", FlagType::Bool).alias("ag").alias("a");
             assert_eq!(f.option_index(&v), Some(2));
         }
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod context;
 pub mod error;
 mod flag;
 mod help;
+mod utils;
 
 pub use action::{Action, ActionWithResult};
 pub use app::App;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,26 @@
+/// Split arg with "=" to unify arg notations.
+/// --flag=value => ["--flag", "value"]
+/// --flag value => ["--flag", "value"]
+/// -abe => ["-a", "-b", "-e"]
+/// -abef=32 => ["-a", "-b", "-e", "-f", "32"]
+pub fn normalized_args(raw_args: Vec<String>) -> Vec<String> {
+    raw_args.iter().fold(Vec::<String>::new(), |mut acc, cur| {
+        if cur.starts_with('-') && !cur.starts_with("--") {
+            if cur.contains('=') {
+                let splitted_flag: Vec<String> = cur.splitn(2, '=').map(|s| s.to_owned()).collect();
+                let short_named = splitted_flag[0].chars().skip(1).map(|c| format!("-{}", c));
+                acc.append(&mut short_named.collect());
+                acc.append(&mut splitted_flag[1..].to_vec());
+            } else {
+                let short_named = cur.chars().skip(1).map(|c| format!("-{}", c));
+                acc.append(&mut short_named.collect());
+            }
+        } else if cur.starts_with('-') && cur.contains('=') {
+            let mut splitted_flag: Vec<String> = cur.splitn(2, '=').map(|s| s.to_owned()).collect();
+            acc.append(&mut splitted_flag);
+        } else {
+            acc.push(cur.to_owned());
+        }
+        acc
+    })
+}


### PR DESCRIPTION
Align use of '-' and '--' with other CLI parsers
The use a single '-' is usually for short options a single char. Also
the way it is used in all tests. One of the example has an alias "ag"
which currently is parsed if the argument is '-ag' with this change
aliases with more the a single char need to be parsed with double
dash - as e.g. '--ag'